### PR TITLE
refactor: simplificar estructuras de datos

### DIFF
--- a/philo/init.c
+++ b/philo/init.c
@@ -16,19 +16,19 @@ int	init_mutexes(t_data *data)
 {
 	int	i;
 
-	data->locks.forks = malloc(sizeof(pthread_mutex_t) * data->num_philos);
-	if (!data->locks.forks)
+	data->forks = malloc(sizeof(pthread_mutex_t) * data->num_philos);
+	if (!data->forks)
 		return (ft_error(MSG_MALLOC_ERR));
 	i = 0;
 	while (i < data->num_philos)
 	{
-		if (pthread_mutex_init(&data->locks.forks[i], NULL))
+		if (pthread_mutex_init(&data->forks[i], NULL))
 			return (ft_error(MSG_MALLOC_ERR));
 		i++;
 	}
-	if (pthread_mutex_init(&data->locks.write_lock, NULL) \
-			|| pthread_mutex_init(&data->locks.meal_lock, NULL) \
-			|| pthread_mutex_init(&data->locks.death_lock, NULL))
+	if (pthread_mutex_init(&data->write_lock, NULL) \
+			|| pthread_mutex_init(&data->meal_lock, NULL) \
+			|| pthread_mutex_init(&data->death_lock, NULL))
 		return (ft_error(MSG_MALLOC_ERR));
 	return (0);
 }
@@ -46,8 +46,8 @@ int	init_philos(t_data *data)
 	{
 		data->philos[i].id = i + 1;
 		data->philos[i].data = data;
-		data->philos[i].forks[LEFT] = &data->locks.forks[i];
-		data->philos[i].forks[RIGHT] = &data->locks.forks[(i + 1) % data->num_philos];
+		data->philos[i].forks[LEFT] = &data->forks[i];
+		data->philos[i].forks[RIGHT] = &data->forks[(i + 1) % data->num_philos];
 		i++;
 	}
 	return (0);

--- a/philo/main.c
+++ b/philo/main.c
@@ -20,9 +20,9 @@ int	ft_error(char *msg)
 static	int	check_args(int argc, char *argv[], t_data *data)
 {
 	if (!ft_philo_atoi(argv[1], &data->num_philos)
-		|| !ft_philo_atoi(argv[2], &data->times.to_die)
-		|| !ft_philo_atoi(argv[3], &data->times.to_eat)
-		|| !ft_philo_atoi(argv[4], &data->times.to_sleep)
+		|| !ft_philo_atoi(argv[2], &data->time_to_die)
+		|| !ft_philo_atoi(argv[3], &data->time_to_eat)
+		|| !ft_philo_atoi(argv[4], &data->time_to_sleep)
 		|| (argc == 6 && !ft_philo_atoi(argv[5], &data->num_meals)))
 		return (ft_error(MSG_INVALID_ARGS));
 	if (argc == 5)
@@ -48,22 +48,22 @@ void	clean_data(t_data *data)
 
 	if (!data)
 		return ;
-	if (data->locks.forks)
+	if (data->forks)
 	{
 		i = 0;
 		while (i < data->num_philos)
 		{
-			if (pthread_mutex_destroy(&data->locks.forks[i]) != 0)
+			if (pthread_mutex_destroy(&data->forks[i]) != 0)
 				printf("%s" MSG_FORK_DESTROY_ERR "%s\n", RED, i, RESET);
 			i++;
 		}
-		free(data->locks.forks);
+		free(data->forks);
 	}
-	if (pthread_mutex_destroy(&data->locks.write_lock) != 0)
+	if (pthread_mutex_destroy(&data->write_lock) != 0)
 		printf("%s" MSG_MUTEX_DESTROY_ERR "%s\n", RED, "write lock", RESET);
-	if (pthread_mutex_destroy(&data->locks.meal_lock) != 0)
+	if (pthread_mutex_destroy(&data->meal_lock) != 0)
 		printf("%s" MSG_MUTEX_DESTROY_ERR "%s\n", RED, "meal lock", RESET);
-	if (pthread_mutex_destroy(&data->locks.death_lock) != 0)
+	if (pthread_mutex_destroy(&data->death_lock) != 0)
 		printf("%s" MSG_MUTEX_DESTROY_ERR "%s\n", RED, "death lock", RESET);
 	if (data->philos)
 		free(data->philos);

--- a/philo/philo.h
+++ b/philo/philo.h
@@ -51,53 +51,32 @@
 # define GOLD	"\033[38;5;220m"
 # define GREEN	"\033[38;5;120m"
 
+/* Fork indices */
+# define LEFT 0
+# define RIGHT 1
+
 typedef struct s_philo	t_philo;
 
-typedef enum e_fork_side
+typedef struct s_data
 {
-	LEFT = 0,
-	RIGHT = 1
-}	t_fork_side;
-
-typedef enum e_state
-{
-	THINKING = 0,
-	EATING = 1,
-	SLEEPING = 2,
-	DEAD = 3
-}	t_state;
-
-typedef struct s_timings
-{
-	int		to_die;
-	int		to_eat;
-	int		to_sleep;
-}	t_timings;
-
-typedef struct s_mutex
-{
+	int				num_philos;
+	int				time_to_die;
+	int				time_to_eat;
+	int				time_to_sleep;
+	int				num_meals;
+	int				all_ate;
+	int				someone_died;
+	long			start_time;
 	pthread_mutex_t	*forks;
 	pthread_mutex_t	write_lock;
 	pthread_mutex_t	meal_lock;
 	pthread_mutex_t	death_lock;
-}	t_mutex;
-
-typedef struct s_data
-{
-	int			num_philos;
-	int			num_meals;
-	int			all_ate;
-	int			someone_died;
-	long		start_time;
-	t_philo		*philos;
-	t_timings	times;
-	t_mutex		locks;
+	t_philo			*philos;
 }	t_data;
 
 typedef struct s_philo
 {
 	int				id;
-	t_state			state;
 	int				meals_eaten;
 	long			last_meal_time;
 	pthread_mutex_t	*forks[2];
@@ -105,11 +84,13 @@ typedef struct s_philo
 	t_data			*data;
 }	t_philo;
 
+/* Function prototypes */
 int		ft_philo_atoi(const char *str, int *result);
 void	print_status(t_philo *philo, char *msg);
 long	get_time(void);
 int		ft_error(char *msg);
 int		init_philos(t_data *data);
 int		init_mutexes(t_data *data);
+void	*philosopher_routine(void *arg);
 
 #endif

--- a/philo/routine.c
+++ b/philo/routine.c
@@ -27,11 +27,11 @@ static void	eat(t_philo *philo)
 	if (!philo)
 		return ;
 	print_status(philo, MSG_EAT);
-	pthread_mutex_lock(&philo->data->locks.meal_lock);
+	pthread_mutex_lock(&philo->data->meal_lock);
 	philo->last_meal_time = get_time();
 	philo->meals_eaten++;
-	pthread_mutex_unlock(&philo->data->locks.meal_lock);
-	usleep(philo->data->times.to_eat * 1000);
+	pthread_mutex_unlock(&philo->data->meal_lock);
+	usleep(philo->data->time_to_eat * 1000);
 	pthread_mutex_unlock(philo->forks[RIGHT]);
 	pthread_mutex_unlock(philo->forks[LEFT]);
 }
@@ -41,7 +41,7 @@ static void	sleep_and_think(t_philo *philo)
 	if (!philo)
 		return ;
 	print_status(philo, MSG_SLEEP);
-	usleep(philo->data->times.to_sleep * 1000);
+	usleep(philo->data->time_to_sleep * 1000);
 	print_status(philo, MSG_THINK);
 }
 
@@ -52,7 +52,7 @@ void	*philosopher_routine(void *arg)
 	philo = (t_philo *)arg;
 	if (philo->id % 2 == 0)
 		usleep(1000);
-	while (!philo->data->someone_died && (philo->data->num_meals == -1\
+	while (!philo->data->someone_died && (philo->data->num_meals == -1 \
 	|| philo->meals_eaten < philo->data->num_meals))
 	{
 		take_forks(philo);

--- a/philo/utils.c
+++ b/philo/utils.c
@@ -59,7 +59,7 @@ void	print_status(t_philo *philo, char *msg)
 
 	if (!philo || !msg || !philo->data)
 		return ;
-	pthread_mutex_lock(&philo->data->locks.write_lock);
+	pthread_mutex_lock(&philo->data->write_lock);
 	if (!philo->data->someone_died)
 	{
 		timestamp = get_time();
@@ -69,5 +69,5 @@ void	print_status(t_philo *philo, char *msg)
 			printf("%ld %d %s\n", timestamp, philo->id, msg);
 		}
 	}
-	pthread_mutex_unlock(&philo->data->locks.write_lock);
+	pthread_mutex_unlock(&philo->data->write_lock);
 }


### PR DESCRIPTION
CAMBIOS REALIZADOS:
- Eliminadas estructuras anidadas innecesarias (t_timings y t_mutex)
- Convertidos enums en defines simples (LEFT y RIGHT)
- Eliminado enum t_state por ser innecesario
- Simplificada estructura t_data:
  * Mutexes ahora directamente en t_data
  * Variables de tiempo renombradas para mayor claridad
  * Eliminadas estructuras intermedias
- Simplificada estructura t_philo:
  * Eliminado campo state innecesario
  * Mantenida la funcionalidad esencial

RAZONES:
1. Mejor mantenibilidad: código más directo y fácil de entender
2. Menos indirección: acceso directo a variables y mutexes
3. Menor complejidad: eliminación de capas innecesarias
4. Mayor claridad: nombres más descriptivos para variables de tiempo
5. Mejor rendimiento: menos dereferencias de punteros

Estos cambios mantienen toda la funcionalidad mientras hacen el código más limpio y eficiente.